### PR TITLE
Revert "Revert "added BOptimist to retry failed builds""

### DIFF
--- a/src/jenkins_tools/resources/templates/jenkins_template.xml
+++ b/src/jenkins_tools/resources/templates/jenkins_template.xml
@@ -32,7 +32,7 @@
     <hudson.tasks.Shell>
       <command>
 export JENKINS_SCRIPTS_REPOSITORY_URL=https://github.com/strands-project/jenkins_scripts.git
-bash run_chroot_local @(UBUNTU_DISTRO) @(ARCH) $WORKSPACE @(SCRIPT) @(SCRIPT_ARGS)
+boptimist.py --retry 3 -- bash run_chroot_local @(UBUNTU_DISTRO) @(ARCH) $WORKSPACE @(SCRIPT) @(SCRIPT_ARGS)
      </command>
     </hudson.tasks.Shell>
   </builders>


### PR DESCRIPTION
Reverts strands-project/jenkins_tools#1

So, seems we still need boptimist once in a while :disappointed: 
